### PR TITLE
feat: Do not set a default sourceAccountIdentifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-clisk": "^0.22.2",
-    "date-fns": "2.30.0"
+    "date-fns": "2.30.0",
+    "p-wait-for": "5.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ Minilog.enable('soshCCC')
 
 const BASE_URL = 'https://www.sosh.fr'
 const DEFAULT_PAGE_URL = BASE_URL + '/client'
+const LOGIN_FORM_PAGE = 'https://login.orange.fr/?service=sosh&return_url=https%3A%2F%2Fwww.sosh.fr%2F&propagation=true&domain=sosh&force_authent=true'
 
 let recentBills = []
 let oldBills = []
@@ -44,7 +45,7 @@ window.XMLHttpRequest.prototype.open = function () {
     })
     return proxied.apply(this, [].slice.call(arguments))
   }
-  // Intercepting user adresse infomations for Identity object
+  // Intercepting user infomations for Identity object
   if (arguments[1].includes('ecd_wp/account/billingAddresses')) {
     originalResponse.addEventListener('readystatechange', function () {
       if (originalResponse.readyState === 4) {
@@ -92,7 +93,7 @@ class SoshContentScript extends ContentScript {
   async navigateToLoginForm() {
     this.log('info', '🤖 navigateToLoginForm starts')
     await this.goto(
-      'https://login.orange.fr/?service=sosh&return_url=https%3A%2F%2Fwww.sosh.fr%2F&propagation=true&domain=sosh&force_authent=true'
+      LOGIN_FORM_PAGE
     )
     await Promise.race([
       this.waitForElementInWorker('#login-label'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { ContentScript } from 'cozy-clisk/dist/contentscript'
 import { blobToBase64 } from 'cozy-clisk/dist/contentscript/utils'
 import Minilog from '@cozy/minilog'
+import waitFor from 'p-wait-for'
 
 const log = Minilog('ContentScript')
 Minilog.enable('soshCCC')
@@ -808,7 +809,7 @@ class SoshContentScript extends ContentScript {
     return false
   }
 
-  async waitForCaptchaResolution() {
+  async checkCaptchaResolution() {
     const passwordInput = document.querySelector('#password')
     const loginInput = document.querySelector('#login')
     const otherAccountButton = document.querySelector('#undefined-label')
@@ -819,6 +820,14 @@ class SoshContentScript extends ContentScript {
       return true
     }
     return false
+  }
+
+  async waitForCaptchaResolution() {
+    await waitFor(this.checkCaptchaResolution, {
+      interval: 1000,
+      timeout: 60 * 1000
+    })
+    return true
   }
 
   async getFileName(date, amount, vendorRef) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ Minilog.enable('soshCCC')
 
 const BASE_URL = 'https://www.sosh.fr'
 const DEFAULT_PAGE_URL = BASE_URL + '/client'
-const DEFAULT_SOURCE_ACCOUNT_IDENTIFIER = 'sosh'
 
 let recentBills = []
 let oldBills = []
@@ -187,9 +186,9 @@ class SoshContentScript extends ContentScript {
     this.log('info', '🤖 getUserDataFromWebsite starts')
     const sourceAccountId = await this.runInWorker('getUserMail')
     if (sourceAccountId === 'UNKNOWN_ERROR') {
-      this.log('debug', "Couldn't get a sourceAccountIdentifier, using default")
-      return { sourceAccountIdentifier: DEFAULT_SOURCE_ACCOUNT_IDENTIFIER }
+      throw new Error('Could not get a sourceAccountIdentifier')
     }
+
     return {
       sourceAccountIdentifier: sourceAccountId
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,7 +3732,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-p-wait-for@^5.0.2:
+p-wait-for@5.0.2, p-wait-for@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-5.0.2.tgz#1546a15e64accf1897377cb1507fa4c756fffe96"
   integrity sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==


### PR DESCRIPTION
This may cause silent errors later, it is better to fail in this case.

- feat: Do not set a default sourceAccountIdentifier
- fix: Add waitFor in runInWorkerUntilTrue
