### PR TITLE
feat: Enhance the fetch of contracts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,6 @@ class SoshContentScript extends ContentScript {
         this.log('info', 'no credentials found, use normal user login')
         await this.waitForUserAuthentication()
       }
-      await this.detectOrangeOnlyAccount()
     }
   }
 
@@ -554,7 +553,7 @@ class SoshContentScript extends ContentScript {
     await this.runInWorker('click', 'a[href="/compte?sosh="]')
     await this.waitForElementInWorker('p', {
       includesText: 'Infos de contact'
-    }),
+    })
     await this.runInWorker('click', 'p', { includesText: 'Infos de contact' })
     await Promise.all([
       this.waitForElementInWorker(
@@ -629,21 +628,6 @@ class SoshContentScript extends ContentScript {
       this.log('info', 'filling password field')
       document.querySelector('#password').value = credentials.password
       return
-    }
-  }
-
-  async detectOrangeOnlyAccount() {
-    await this.goto(DEFAULT_PAGE_URL)
-    await this.waitForElementInWorker('strong')
-    const isSosh = await this.runInWorker(
-      'checkForElement',
-      `#oecs__logo[href="https://www.sosh.fr/"]`
-    )
-    this.log('info', 'isSosh ' + isSosh)
-    if (!isSosh) {
-      throw new Error(
-        'This should be sosh account. Found only orange contracts'
-      )
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ class SoshContentScript extends ContentScript {
         this.waitForElementInWorker('div[class*="captcha_responseContainer"]'),
         this.waitForElementInWorker('#undefined-label'),
         this.waitForElementInWorker('#oecs__popin-icon-Identification'),
+        this.waitForElementInWorker('#changeAccountLink'),
         this.waitForErrorUrl()
       ],
       'navigateToLoginForm: waiting for login page load'
@@ -104,6 +105,14 @@ class SoshContentScript extends ContentScript {
         '#oecs__connecte-changer-utilisateur',
         '#undefined-label'
       )
+    }
+
+    const isChangAccountLinkPresent = await this.isElementInWorker(
+      '#changeAccountLink'
+    )
+    this.log('info', 'isChangAccountLinkPresent: ' + isChangAccountLinkPresent)
+    if (isChangAccountLinkPresent) {
+      await this.clickAndWait('#changeAccountLink', '#undefined-label')
     }
 
     if (await this.isElementInWorker('#undefined-label')) {
@@ -298,6 +307,7 @@ class SoshContentScript extends ContentScript {
         this.waitForElementInWorker(
           'button[data-testid="button-keepconnected"]'
         ),
+        this.waitForElementInWorker('button[data-testid="button-reload"]'),
         this.waitForElementInWorker(passwordInputSelector),
         this.waitForErrorUrl()
       ],
@@ -308,6 +318,14 @@ class SoshContentScript extends ContentScript {
       'button[data-testid="button-keepconnected"]'
     )
     this.log('info', 'isShowingKeepConnected: ' + isShowingKeepConnected)
+    const isShowingButtonReload = await this.isElementInWorker(
+      'button[data-testid="button-reload"]'
+    )
+    this.log('info', 'isShowingButtonReload: ' + isShowingButtonReload)
+
+    if (isShowingButtonReload) {
+      await this.runInWorker('click', 'button[data-testid="button-reload"]')
+    }
 
     if (isShowingKeepConnected) {
       await this.runInWorker(


### PR DESCRIPTION
Now the fetch of multiple contract is easier to maintain (I think at least)

- get the list of contracts from json api
- only fetch sosh contracts
- define a subpath for each contract
- distinction of isp or mobile contracts

Also remove the detection of orange only account which was not reliable.
Also handle more authentication phases but some are still missing.