### PR TITLE
Feat/context upgrades

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,14 +107,19 @@ class SoshContentScript extends ContentScript {
       return true
     }
     await this.goto(LOGIN_FORM_PAGE)
-    await Promise.race([
-      this.waitForElementInWorker('#login-label'),
-      this.waitForElementInWorker('#password-label'),
-      this.waitForElementInWorker('button[data-testid="button-keepconnected"]'),
-      this.waitForElementInWorker('div[class*="captcha_responseContainer"]'),
-      this.waitForElementInWorker('#undefined-label'),
-      this.waitForElementInWorker('#oecs__connecte-se-deconnecter')
-    ])
+    await this.PromiseRaceWithError(
+      [
+        this.waitForElementInWorker('#login-label'),
+        this.waitForElementInWorker('#password-label'),
+        this.waitForElementInWorker(
+          'button[data-testid="button-keepconnected"]'
+        ),
+        this.waitForElementInWorker('div[class*="captcha_responseContainer"]'),
+        this.waitForElementInWorker('#undefined-label'),
+        this.waitForElementInWorker('#oecs__connecte-se-deconnecter')
+      ],
+      'navigateToLoginForm: waiting for login page load'
+    )
     const loginLabelPresent = await this.isElementInWorker('#login-label')
     this.log('info', 'loginLabelPresent: ' + loginLabelPresent)
     const passwordLabelPresent = await this.isElementInWorker('#password-label')
@@ -209,6 +214,7 @@ class SoshContentScript extends ContentScript {
     await this.waitForElementInWorker(
       '#login, #password, div[class*="captcha_responseContainer"], button[data-testid="button-keepconnected"], #oecs__connexion, #oecs__connecte-se-deconnecter'
     )
+    // Website could trigger a captcha when reaching for homePage, it's weird but it happen, so we're covering the case
     await this.handleCaptcha()
     const connectionButton = await this.isElementInWorker('#oecs__connexion')
     const loginInput = await this.isElementInWorker('#login')

--- a/src/index.js
+++ b/src/index.js
@@ -339,6 +339,19 @@ class SoshContentScript extends ContentScript {
     await this.runInWorker('click', loginButtonSelector)
   }
 
+  async logout() {
+    this.log('info', '📍️ logout starts')
+    try {
+      await this.clickAndWait(
+        '#oecs__connecte-se-deconnecter',
+        '#oecs__connexion'
+      )
+    } catch (e) {
+      log('error', 'Not completly disconnected, never found the second link')
+      throw e
+    }
+  }
+
   async fetch(context) {
     this.log('info', '🤖 fetch start')
     if (this.store.userCredentials != undefined) {
@@ -389,6 +402,8 @@ class SoshContentScript extends ContentScript {
     await this.navigateToPersonalInfos()
     await this.runInWorker('getIdentity')
     await this.saveIdentity(this.store.infosIdentity)
+    // Logging out every run to avoid in between scenarios and sosh/orange mismatched sessions
+    await this.logout()
   }
 
   async getNumberOfContracts() {

--- a/src/index.js
+++ b/src/index.js
@@ -230,9 +230,12 @@ class SoshContentScript extends ContentScript {
       .map(contract => ({
         vendorId: contract.cid,
         brand: contract.brand.toLowerCase(),
-        label: contract.offerName,
+        label: contract.offerName.match(/\d{1,3},\d{2}€/)
+          ? contract.offerName.replace(/\s\d{1,3},\d{2}€/, '')
+          : contract.offerName,
         type: contract.vertical.toLowerCase() === 'mobile' ? 'phone' : 'isp',
-        holder: contract.holder
+        holder: contract.holder,
+        number: contract.telco.publicNumber
       }))
       .filter(contract => contract.brand === 'sosh')
   }
@@ -392,7 +395,7 @@ class SoshContentScript extends ContentScript {
         context,
         fileIdAttributes: ['vendorRef'],
         contentType: 'application/pdf',
-        subPath: `${contract.label} - ${contract.vendorId}`,
+        subPath: `${contract.number} - ${contract.label} - ${contract.vendorId}`,
         qualificationLabel:
           contract.type === 'phone' ? 'phone_invoice' : 'isp_invoice'
       })
@@ -404,7 +407,7 @@ class SoshContentScript extends ContentScript {
         context,
         fileIdAttributes: ['vendorRef'],
         contentType: 'application/pdf',
-        subPath: `${contract.label} - ${contract.vendorId}`,
+        subPath: `${contract.number} - ${contract.label} - ${contract.vendorId}`,
         qualificationLabel:
           contract.type === 'phone' ? 'phone_invoice' : 'isp_invoice'
       })

--- a/src/index.js
+++ b/src/index.js
@@ -417,22 +417,6 @@ class SoshContentScript extends ContentScript {
     await this.logout()
   }
 
-  async getNumberOfContracts() {
-    this.log('info', '📍️ getNumberOfContracts starts')
-    const contractsElements = document.querySelectorAll(
-      '.dashboardConso__contracts li'
-    )
-    let allContractsInfos = []
-    for (const contract of contractsElements) {
-      const contractInfos = contract.textContent
-        .match(/([A-Za-z])*\s(\d{2}\s\d{2}\s\d{2}\s\d{2}\s\d{2})/g)[0]
-        .split(/(?<=\D)\s/)
-      const [type, phone] = contractInfos
-      allContractsInfos.push({ type, phone })
-    }
-    await this.sendToPilot({ allContractsInfos })
-  }
-
   async navigateToNextContract(index) {
     this.log('info', '📍️ navigateToNextContract starts')
     const wantedContractNumber = this.store.allContractsInfos[index].phone
@@ -783,7 +767,6 @@ connector
       'waitForUndefinedLabelReallyClicked',
       'checkErrorUrl',
       'checkMoreBillsButton',
-      'getNumberOfContracts',
       'getContracts'
     ]
   })


### PR DESCRIPTION
This PR completes the missing login/logout scenarios of previous branch `feat/enhancedFetchContracts` and adds context upgrades on the konnector.

We're now logging out on every execution, at the beginning if needed (to avoid in between scenarios where you could be sort of "half logged" and mismatch sessions between Orange and Sosh konnectors executions) bringing us to 4 scenarios to handle.

- First execution (no account, not connected) : Let user login, intercept credentials, fetch and logout
- AutoLogin (account and not connected) : autoLogin, fetch and logout
- AutoLogin (account and already connected because last execution crashed) : preventive logout, autoLogin, fetch, logout
- Bonus case ( konnector crashed on last execution, and somehow user remove cozy account => No account, already connected) : preventive logout, let user login, intercept credentials, fetch and logout