### PR TITLE
[SCR-84] feat: Implement ensureNotAuthenticated with a kind of state machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@cozy/minilog": "1.0.0",
-    "cozy-clisk": "^0.32.0",
+    "cozy-clisk": "^0.32.1",
     "date-fns": "3.2.0",
     "p-wait-for": "5.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-clisk": "^0.32.0",
-    "date-fns": "2.30.0",
+    "date-fns": "3.2.0",
     "p-wait-for": "5.0.2"
   },
   "eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,12 @@ class SoshContentScript extends ContentScript {
       )
     } else {
       const checkBox = document.querySelector('#remember')
-      checkBox.click()
-      // Setting the visibility to hidden on the parent to make the element disapear
-      // preventing users to click it
-      checkBox.parentNode.parentNode.style.visibility = 'hidden'
+      if (checkBox) {
+        checkBox.click()
+        // Setting the visibility to hidden on the parent to make the element disapear
+        // preventing users to click it
+        checkBox.parentNode.parentNode.style.visibility = 'hidden'
+      }
     }
     this.log('info', 'password element found, adding listener')
     addClickListener.bind(this)()

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,7 @@ class SoshContentScript extends ContentScript {
     }
     // Necessary here for the interception to cover every known scenarios
     // Doing so we ensure if the logout leads to the password step that the listener won't start until the user has filled up the login
-    await this.waitForElementNoReload('#login')
-    await this.waitForElementNoReload('#password')
+    await this.waitForDomReady()
     if (
       !(await this.checkForElement('#remember')) &&
       (await this.checkForElement('#password'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,10 +2010,10 @@ cozy-client@^41.2.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.32.0.tgz#9b7e6180ec4aaee52722d4eb8ae6b5ce2b27119a"
-  integrity sha512-WmxfU+rYFLpOWmEAnhKowD7dirLgvKB3andt8aJbbzqQqif8cMgUUMKJZyMGhEgydvWAIB+cqIjRMGaHYE41vg==
+cozy-clisk@^0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.32.1.tgz#6d095ff42c8b644bfcddacc2c730cb3490b24543"
+  integrity sha512-NaLIYPuW5ySQRP1YpV9kxALpaMgsdZLCDueHTdV1ElMbGSWL/Nrv+iufqUohEaNxqwez0SphUCws4ousLiRNjg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,13 +989,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.21.0":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
-  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/template@^7.16.7", "@babel/template@^7.18.10", "@babel/template@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2146,12 +2139,10 @@ date-fns@2.29.3:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
-date-fns@2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
+date-fns@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.2.0.tgz#c97cf685b62c829aa4ecba554e4a51768cf0bffc"
+  integrity sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
Since the number of paths in logout has lot of possible combinations, we
cannot predict all the possible path and which state of the page takes
place before the next.

I then tried to implement a kind of finite state machine where we
identify all the possible states before the login page :

- connected
- disconnected
- error page
- captcha
- login page
- login page whith only password field
- list of accounts
- keep konnected button
- reload page button
- consent page

For each of these states, we know how to change the state to tend the
final login state and we check the current state in a loop until the
login page state is displayed

If we get an unknown state, an error will be thrown and it will be
possible to know the state with the clisk.html-on-error flag

If the loop is infinit, it will timeout and the logs will display the
path of states.

I hope this will the this connector more stable and more adaptative to
changes in the navigation.

- feat: Upgrade date-fns to last version
- feat: use waitForDomReady
- fix: Protect against non existing checkbox
- feat: Implement ensureNotAuthenticated with a kind of state machine
