### PR TITLE
chore: Avoid publishing when built in cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 deploy:
 - provider: script
   skip-cleanup: true
-  script: DEPLOY_BRANCH=build yarn deploy && yarn cozyPublish
+  script: if [[ "${TRAVIS_EVENT_TYPE}" != "cron" ]]; then DEPLOY_BRANCH=build yarn deploy && yarn cozyPublish; else true; fi
   on:
     branch: master
 - provider: script


### PR DESCRIPTION
Skip travis deploy stage when built in cron.

This way, we keep build & tests daily in travis cron job but avoid to pollute the registry with unneeded daily dev version