### PR TITLE
[SCR-741] Fix/no bills to dl

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -437,8 +437,13 @@ class SoshContentScript extends ContentScript {
     const { trigger } = context
     // force fetch all data (the long way) when last trigger execution is older than 90 days
     // or when the last job was an error
+    const isFirstJob =
+      !trigger.current_state?.last_failure &&
+      !trigger.current_state?.last_success
     const isLastJobError =
+      !isFirstJob &&
       trigger.current_state?.last_failure > trigger.current_state?.last_success
+
     const hasLastExecution = Boolean(trigger.current_state?.last_execution)
     const distanceInDays = getDateDistanceInDays(
       trigger.current_state?.last_execution


### PR DESCRIPTION
This PR do four things : 
- It ensure actual contract has at least one available bill before trying to scrap it
- It avoid identity scraping if the konnector detects the wrong page (we had some case, for obscure reasons, leading to the "numeric accessibility score" of the website.) There is no element to click to get back where intended as it litteraly change the website domain. I cannot explain this, so this is a workaround
- It ensure context is handled properly => We notice the quick and slow execution were not defined as intended.
- Very recently, Orange (and Sosh by extension) made some modifications on how they were handling contracts & bills. Apparently those modifications kind of mess with the recentBills (under one year old) download, as even on browser like a normal user, we get for everyone of those a 403 error. We're now kind of checking the bill availability before download, and throw a warning when detected. 
This is a bit tricky as it match the "Forbidden" error, so we gotta be careful here, and ask the user to check bill availibility on his side if this error is encountered in production.