### PR TITLE
feat: Use try/catch to avoid crash on missing element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -716,19 +716,24 @@ class SoshContentScript extends ContentScript {
       this.store.skippingIdentity = true
     }
     await this.runInWorker('click', 'p', { includesText: 'Infos de contact' })
-
-    // Using allSettle here because we notice some account did not have adresses registered
-    await Promise.allSettled([
+    await Promise.all([
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-modifier-votre-identite"]'
       ),
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-phone-modifier"]'
-      ),
-      this.waitForElementInWorker(
-        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]', {timeout: 5000}
       )
     ])
+    // Some users does not have any adresse registered on theur account, we got to treat this separatedly to avoid konnector crashing
+    try {
+      await this.waitForElementInWorker(
+        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]',
+        { timeout: 5000 }
+      )
+    } catch (_) {
+      // Catch it so it don't crash, no big deal if not available
+      this.log('warn', 'Address element is not present on the page')
+    }
   }
 
   async waitForUserAction(url) {

--- a/src/index.js
+++ b/src/index.js
@@ -716,7 +716,9 @@ class SoshContentScript extends ContentScript {
       this.store.skippingIdentity = true
     }
     await this.runInWorker('click', 'p', { includesText: 'Infos de contact' })
-    await Promise.all([
+
+    // Using allSettle here because we notice some account did not have adresses registered
+    await Promise.allSettled([
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-modifier-votre-identite"]'
       ),
@@ -724,7 +726,7 @@ class SoshContentScript extends ContentScript {
         'a[data-e2e="btn-contact-info-phone-modifier"]'
       ),
       this.waitForElementInWorker(
-        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]'
+        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]', {timeout: 5000}
       )
     ])
   }


### PR DESCRIPTION
This PR is fixing the missing element crash occuring when a user did not have any addresses registered in his account. As identity is not mandatory and is already conditionned for missing infos, it should avoid the konnector's crash.

Edit :

promise.allSettled being relatively recent, it is preferable not to use it to cover older devices/browsers that could not use it. 
Now it is simply done with a try/catch to avoid the crash if the element is not present.